### PR TITLE
Add Dectalk to CFC HTTP Whitelist

### DIFF
--- a/lua/cfc_http_restrictions/list_manager.lua
+++ b/lua/cfc_http_restrictions/list_manager.lua
@@ -70,6 +70,9 @@ CFCHTTP.allowedAddresses = {
     ["cfcservers.org"] = {allowed=true, isPermanent=true},
     ["google.com"] = {allowed=true, isPermanent=true},
     ["www.google.com"] = {allowed=true, isPermanent=true},
+
+    -- dectalk
+    ["tts.cyzon.us"] = {allowed=true},
 }
 
 AddressCache = {}


### PR DESCRIPTION
I looked at the examples in the list manager and did my best to figure out what is required to include Dectalk (tts.cyzon.us) to our HTTP Whitelist. As far as I know, we shouldn't need a pattern for this entry.