### PR TITLE
Add in latest whitelisted remotes from StarfallEx

### DIFF
--- a/lua/cfc_http_restrictions/default_config.lua
+++ b/lua/cfc_http_restrictions/default_config.lua
@@ -74,6 +74,9 @@ return {
 
         ["cdn[%w-_]*.discordapp%.com"] = { allowed = true, pattern = true },
         ["images-([%w%-]+)%.discordapp%.net"] = { allowed = true, pattern = true },
-        ["i([%w-_]+)%.tinypic%.com"] = { allowed = true, pattern = true }
+        ["i([%w-_]+)%.tinypic%.com"] = { allowed = true, pattern = true },
+
+        ["(%w+)%.keybase.pub/(.+)"] = { allowed = true },
+        ["tts.cyzon.us/(.+)"] = { allowed = true }
     }
 }


### PR DESCRIPTION
Adds new whitelisted remotes from the [StarfallEx repository](https://github.com/thegrb93/StarfallEx/blob/master/lua/starfall/permissions/providers_sh/url_whitelist.lua), which whitelists `keybase.pub` and `tts.cyzon.us`.