### PR TITLE
remove parsed address cache

### DIFF
--- a/lua/cfc_http_restrictions/shared/url.lua
+++ b/lua/cfc_http_restrictions/shared/url.lua
@@ -59,18 +59,11 @@ function CFCHTTP.ReplaceURLs( text, f )
     return html
 end
 
----@type table<string, string>
-local parsedAddressCache = {}
-
 ---@param url string
 ---@return string|nil
 function CFCHTTP.GetAddress( url )
     if not url then return end
-    local cached = parsedAddressCache[url]
-    if cached then return cached end
-
     local data = CFCHTTP.ParseURL( url )
-    parsedAddressCache[url] = data.address
 
     return data.address
 end


### PR DESCRIPTION
The performance benefit from this is pretty small and complicating the caching logic to resolve #39 makes that difference even smaller, and in some cases worse.

It would be better to do caching around the CFCHTTP.GetOptionsForURL function