### PR TITLE
Add *.googleusercontent.com

### DIFF
--- a/lua/cfc_http_restrictions/default_config.lua
+++ b/lua/cfc_http_restrictions/default_config.lua
@@ -50,6 +50,7 @@ local config = {
         -- google drive
         ["docs.google.com"] = { allowed = true },
         ["drive.google.com"] = { allowed = true },
+        ["*.googleusercontent.com"] = { allowed = true },
 
         -- youtube
         ["www.youtube.com"] = { allowed = true },


### PR DESCRIPTION
Adds another form of google drive urls, allows for links such as https://lh3.googleusercontent.com/drive-viewer/AKGpihbGXqwXIxfK3cxQt1zAZS9JqDAoxGcym7QXxZaj4oZL0YdS56-EOQBksGhlL7zFYzebyjBCP8AYoVbAJSPCdYRryaACeyIf1w=s2560


Can be obtained using sites like https://www.labnol.org/embed/google/drive/ from google drive urls, turns https://drive.google.com/file/d/1HOVECDLAjV_Ry5WtdOvhBtJof3E7NBm5/view?usp=drive_link into the lh3.googleusercontent.com direct url to the image.
