### PR TITLE
Allow imgur.com

### DIFF
--- a/lua/cfc_http_restrictions/default_config.lua
+++ b/lua/cfc_http_restrictions/default_config.lua
@@ -81,6 +81,7 @@ local config = {
         ["bitbucket.org"] = { allowed = true },
 
         ["i.imgur.com"] = { allowed = true },
+        ["imgur.com"] = { allowed = true },
 
         ["pastebin.com"] = { allowed = true },
 


### PR DESCRIPTION
imgur.com has embeds for images and such, odd that it was never whitelisted.