### PR TITLE
Add catbox urls to whitelist

### DIFF
--- a/lua/cfc_http_restrictions/default_config.lua
+++ b/lua/cfc_http_restrictions/default_config.lua
@@ -87,7 +87,7 @@ local config = {
         -- catbox
         ["files.catbox.moe"] = { allowed = true },
         ["catbox.moe"] = { allowed = true },
-        ["litter.catbox.moe:"] = { allowed = true },
+        ["litter.catbox.moe"] = { allowed = true },
         ["litterbox.catbox.moe"] = { allowed = true },
 
         ["i.imgur.com"] = { allowed = true },

--- a/lua/cfc_http_restrictions/default_config.lua
+++ b/lua/cfc_http_restrictions/default_config.lua
@@ -84,6 +84,12 @@ local config = {
         ["i.ibb.co"] = { allowed = true },
         ["api.imgbb.com"] = { allowed = true },
 
+        -- catbox
+        ["files.catbox.moe"] = { allowed = true },
+        ["catbox.moe"] = { allowed = true },
+        ["litter.catbox.moe:"] = { allowed = true },
+        ["litterbox.catbox.moe"] = { allowed = true },
+
         ["i.imgur.com"] = { allowed = true },
         ["imgur.com"] = { allowed = true },
 


### PR DESCRIPTION
Catbox is a very generous no account file sharing site, https://catbox.moe/ supports permanent files, they also have a temp file service called https://litterbox.catbox.moe/